### PR TITLE
Refs 3003, fixes 3008: use properties for version of libraries

### DIFF
--- a/inventory-repository/pom.xml
+++ b/inventory-repository/pom.xml
@@ -66,8 +66,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
 
     <dependency>
       <groupId>net.liftweb</groupId>
-      <artifactId>lift-json_2.9.1</artifactId>
-      <version>2.4</version>
+      <artifactId>lift-json_${scala-lift-version}</artifactId>
+      <version>${lift-version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Only one minor modification that use the globally defined (in parent pom) version of library. 
