### PR TITLE
Fixes #4440: correct the logic that links machine, node, and inventory status

### DIFF
--- a/inventory-provisioning-core/src/main/scala/com/normation/inventory/ldap/provisioning/PostCommits.scala
+++ b/inventory-provisioning-core/src/main/scala/com/normation/inventory/ldap/provisioning/PostCommits.scala
@@ -75,11 +75,11 @@ class AcceptPendingMachineIfServerIsAccepted(
       case (AcceptedInventory,  PendingInventory) =>
         logger.debug("Found machine '%s' in pending DIT but that machine is the container of the accepted node '%s'. Moving machine to accpeted".format(report.machine.id,report.node.main.id))
         // Change the container state, no need to keep the machine
-        val fullInventory = FullInventory(report.node.copy(machineId = Some(report.machine.id,AcceptedInventory)),None)
+        val fullInventory = FullInventory(report.node.copy(machineId = Some((report.machine.id,AcceptedInventory))),None)
         for {
-          res <- fullInventoryRepositoryImpl.move(report.machine.id, PendingInventory, AcceptedInventory)
+          res <- fullInventoryRepositoryImpl.move(report.machine.id, AcceptedInventory)
           // Save Inventory to change the container too, no need to have the machine saved again
-          inventory <- fullInventoryRepositoryImpl.save(fullInventory, AcceptedInventory)
+          inventory <- fullInventoryRepositoryImpl.save(fullInventory)
         } yield {
           logger.debug("Machine '%s' moved to accepted DIT".format(report.machine.id))
           records ++ res ++ inventory

--- a/inventory-repository/src/main/resources/ldap/bootstrap.ldif
+++ b/inventory-repository/src/main/resources/ldap/bootstrap.ldif
@@ -1,8 +1,6 @@
 dn: cn=rudder-configuration
-objectclass: dcObject
-objectclass: organization
-o: Example Company
-dc: example
+objectClass: configurationRoot
+cn: rudder-configuration
 
 dn: ou=Inventories,cn=rudder-configuration
 objectclass: top
@@ -40,7 +38,7 @@ dn: ou=Pending Inventories,ou=Inventories,cn=rudder-configuration
 objectclass: top
 objectclass: organizationalUnit
 ou: Pending Inventories
-description: Store inventories not yet accepted in Rudder 
+description: Store inventories not yet accepted in Rudder
 
 # Machines, pending @ example.org
 

--- a/inventory-repository/src/test/resources/ldap-data/inventory-sample-data.ldif
+++ b/inventory-repository/src/test/resources/ldap-data/inventory-sample-data.ldif
@@ -1,0 +1,273 @@
+
+###################################################################################################
+# Software #
+###################################################################################################
+
+dn: softwareId=soft0,ou=Software,ou=Inventories,cn=rudder-configuration
+softwareId: soft0
+objectClass: software
+objectClass: top
+cn: Software 1
+softwareVersion: 1.0.0
+description: First software
+
+dn: softwareId=soft1,ou=Software,ou=Inventories,cn=rudder-configuration
+softwareId: soft1
+objectClass: software
+objectClass: top
+cn: Software 2
+softwareVersion: 2.0-rc
+description: Second software
+
+###################################################################################################
+# Nodes #
+###################################################################################################
+
+dn: nodeId=root,ou=Nodes,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
+objectClass: top
+objectClass: node
+objectClass: unixNode
+objectClass: linuxNode
+osVersion: nothing
+osName: Ubuntu
+osKernelVersion: nothing
+nodeId: root
+cn: nothing
+localAdministratorAccountName: root
+agentName: Nova
+policyServerId:root
+nodeHostname: root.normation.com
+inventoryDate: 20130515123456.948Z
+
+# Example of a node
+dn: nodeId=node0,ou=Nodes,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
+objectClass: top
+objectClass: node
+objectClass: unixNode
+objectClass: linuxNode
+osVersion: nothing
+osName: Ubuntu
+osKernelVersion: nothing
+nodeId: node0
+cn: nothing
+localAdministratorAccountName: root
+agentName: Nova
+policyServerId:root-policy-server
+nodeHostname: node0.normation.com
+inventoryDate: 20130515123456.948Z
+description: matchOnMe
+#description is the same as a logical 
+#element of node3
+
+# Example of the same (almost) node, but not in ou=nodes
+dn: nodeId=node0_0,ou=Nodes,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
+objectClass: top
+objectClass: node
+objectClass: unixNode
+objectClass: linuxNode
+osVersion: nothing
+osName: Ubuntu
+osKernelVersion: nothing
+nodeId: node0_0
+cn: nothing
+localAdministratorAccountName: root
+agentName: Nova
+nodeHostname: node0_0.normation.com
+policyServerId:root-policy-server
+
+dn: nodeId=node1,ou=Nodes,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
+objectClass: top
+objectClass: node
+objectClass: unixNode
+objectClass: linuxNode
+osVersion: Ubuntu 9.10
+osName: Ubuntu
+osKernelVersion: 2.6.18-17-generic
+nodeId: node1
+cn: has attributes
+swap: 2878000000
+ram: 100000000
+nodeHostname: hasAttributes.normation.com
+description: #54-Ubuntu SMP Thu Dec 10 17:23:29 UTC 2009
+localAccountName: francois.armand
+localAccountName: nicolas.charles
+localAccountName: jonathan.clarke
+localAccountName: root
+localAdministratorAccountName: root
+agentName: Nova
+policyServerId:root-policy-server
+
+# Example of a node
+dn: nodeId=node2,ou=Nodes,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
+objectClass: top
+objectClass: node
+objectClass: unixNode
+objectClass: linuxNode
+osVersion: nothing
+osName: Ubuntu
+osKernelVersion: nothing
+nodeId: node2
+cn:has software
+ram: 1
+software: softwareId=soft0,ou=Software,ou=Inventories,cn=rudder-configuration
+software: softwareId=soft1,ou=Software,ou=Inventories,cn=rudder-configuration
+localAdministratorAccountName: root
+agentName: Nova
+policyServerId:root-policy-server
+nodeHostname: node2.normation.com
+
+dn: nodeId=node3,ou=Nodes,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
+objectClass: top
+objectClass: node
+objectClass: unixNode
+objectClass: linuxNode
+osVersion: nothing
+osName: Ubuntu
+osKernelVersion: nothing
+nodeId: node3
+cn:has logical elements
+localAdministratorAccountName: root
+agentName: Nova
+policyServerId:root-policy-server
+nodeHostname: node3.normation.com
+
+dn: nodeId=node4,ou=Nodes,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
+objectClass: top
+objectClass: node
+objectClass: unixNode
+objectClass: linuxNode
+osVersion: nothing
+osName: Ubuntu
+osKernelVersion: nothing
+nodeId: node4
+container: machineId=machine0,ou=Machines,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
+cn: has machine with nothing
+localAdministratorAccountName: root
+agentName: Community
+policyServerId:root-policy-server
+nodeHostname: node4.normation.com
+
+dn: nodeId=node5,ou=Nodes,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
+objectClass: top
+objectClass: node
+objectClass: unixNode
+objectClass: linuxNode
+osVersion: nothing
+osName: Ubuntu
+osKernelVersion: nothing
+nodeId: node5
+container: machineId=machine1,ou=Machines,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
+cn: has machine with attributes
+localAdministratorAccountName: root
+agentName: Nova
+policyServerId:root-policy-server
+nodeHostname: node5.normation.com
+
+dn: nodeId=node6,ou=Nodes,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
+objectClass: top
+objectClass: node
+objectClass: unixNode
+objectClass: linuxNode
+osVersion: nothing
+osName: Ubuntu
+osKernelVersion: nothing
+nodeId: node6
+container: machineId=machine2,ou=Machines,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
+cn: has machine with physical elements
+localAdministratorAccountName: root
+agentName: Community
+policyServerId:root-policy-server
+nodeHostname: node6.normation.com
+
+dn: nodeId=node7,ou=Nodes,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
+objectClass: top
+objectClass: node
+objectClass: unixNode
+objectClass: linuxNode
+osVersion: nothing
+osName: Ubuntu
+osKernelVersion: nothing
+nodeId: node7
+container: machineId=machine2,ou=Machines,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
+cn: has everything
+software: softwareId=soft0,ou=Software,ou=Inventories,cn=rudder-configuration
+localAdministratorAccountName: root
+agentName: Community
+policyServerId:root-policy-server
+nodeHostname: node7.normation.com
+
+###################################################################################################
+# Logicial Elements #
+###################################################################################################
+
+dn: mountPoint=/,nodeId=node3,ou=Nodes,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
+mountPoint: /
+objectClass: fileSystemLogicalElement
+objectClass: logicalElement
+objectClass: top
+cn: ext3
+fileSystemFreeSpace: 6718226432
+fileSystemTotalSpace: 8038383616
+description: matchOnMe
+
+dn: mountPoint=/,nodeId=node7,ou=Nodes,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
+objectClass: top
+objectClass: logicalElement
+objectClass: fileSystemLogicalElement
+mountPoint: /
+cn: ext3
+fileSystemFreeSpace: 10
+fileSystemTotalSpace: 803838361699
+
+dn: mountPoint=/,nodeId=root,ou=Nodes,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
+objectClass: top
+objectClass: logicalElement
+objectClass: fileSystemLogicalElement
+mountPoint: /
+cn: ext3
+fileSystemFreeSpace: 10
+fileSystemTotalSpace: 803838361699
+
+###################################################################################################
+# Machines #
+###################################################################################################
+
+# Example of a machine whose type is not known
+dn: machineId=machine0,ou=Machines,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
+objectClass: top
+objectClass: device
+objectClass: machine
+machineId: machine0
+cn: no physicalElements
+
+# Example of a physical machine
+dn: machineId=machine1,ou=Machines,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
+objectClass: top
+objectClass: device
+objectClass: machine
+objectClass: physicalMachine
+machineId: has mb - no phys elt
+cn: has motherbord - no physical elements
+motherBoardUuid: f47ac10b-58cc-4372-a567-0e02b2c3d479
+
+# Example of a physical machine
+dn: machineId=machine2,ou=Machines,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
+objectClass: top
+objectClass: device
+objectClass: machine
+objectClass: physicalMachine
+machineId: machine2
+cn: has physicalElements
+
+###################################################################################################
+# Physical elements #
+###################################################################################################
+
+dn: biosName=bios1,machineId=machine2,ou=Machines,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
+biosName: bios1
+objectClass: biosPhysicalElement
+objectClass: physicalElement
+objectClass: top
+editor: Phoenix Technologies LTD
+softwareVersion: 6.00
+

--- a/inventory-repository/src/test/resources/ldap-data/schema/00-core.ldif
+++ b/inventory-repository/src/test/resources/ldap-data/schema/00-core.ldif
@@ -1,0 +1,648 @@
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at
+# trunk/opends/resource/legal-notices/OpenDS.LICENSE
+# or https://OpenDS.dev.java.net/OpenDS.LICENSE.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at
+# trunk/opends/resource/legal-notices/OpenDS.LICENSE.  If applicable,
+# add the following below this CDDL HEADER, with the fields enclosed
+# by brackets "[]" replaced with your own identifying information:
+#      Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+#      Copyright 2006-2009 Sun Microsystems, Inc.
+#
+#
+# This file contains a core set of attribute type and objectlass definitions
+# from several standard LDAP documents (primarily RFCs and IETF Internet
+# Drafts).  The X-ORIGIN component of each name should provide the
+# specification in which that attribute type or objectclass is defined.
+dn: cn=schema
+objectClass: top
+objectClass: ldapSubentry
+objectClass: subschema
+attributeTypes: ( 2.5.4.41 NAME 'name' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{32768}
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.49 NAME 'distinguishedName'
+  EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.0 NAME 'objectClass' EQUALITY objectIdentifierMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.38 X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.4.1 NAME 'aliasedObjectName'
+  EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  SINGLE-VALUE X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.4.2 NAME 'knowledgeInformation' EQUALITY caseIgnoreMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{32768} X-ORIGIN 'RFC 2256' )
+attributeTypes: ( 2.5.4.3 NAME ( 'cn' 'commonName' ) SUP name
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.4 NAME ( 'sn' 'surname' ) SUP name
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.5 NAME 'serialNumber' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.44{64}
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.6 NAME ( 'c' 'countryName' ) SUP name SINGLE-VALUE
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.7 NAME ( 'l' 'localityName' ) SUP name
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.8 NAME ( 'st' 'stateOrProvinceName' ) SUP name
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.9 NAME ( 'street' 'streetAddress' )
+  EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{128}
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.10 NAME ( 'o' 'organizationName' ) SUP name
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.11 NAME ( 'ou' 'organizationalUnitName' ) SUP name
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.12 NAME 'title' SUP name X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.13 NAME 'description' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{1024}
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.14 NAME 'searchGuide'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.25 X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.15 NAME 'businessCategory' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{128}
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.16 NAME 'postalAddress' EQUALITY caseIgnoreListMatch
+  SUBSTR caseIgnoreListSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.41
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.17 NAME 'postalCode' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{40}
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.18 NAME 'postOfficeBox' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{40}
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.19 NAME 'physicalDeliveryOfficeName'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{128} X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.20 NAME 'telephoneNumber' EQUALITY telephoneNumberMatch
+  SUBSTR telephoneNumberSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.50{32}
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.21 NAME 'telexNumber'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.52 X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.22 NAME 'teletexTerminalIdentifier'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.51 X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.23 NAME 'facsimileTelephoneNumber'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.22 X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.24 NAME 'x121Address' EQUALITY numericStringMatch
+  SUBSTR numericStringSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.36{15}
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.25 NAME 'internationaliSDNNumber'
+  EQUALITY numericStringMatch SUBSTR numericStringSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.36{16} X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.26 NAME 'registeredAddress' SUP postalAddress
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.41 X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.27 NAME 'destinationIndicator' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.44{128}
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.28 NAME 'preferredDeliveryMethod'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.14 SINGLE-VALUE X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.29 NAME 'presentationAddress'
+  EQUALITY presentationAddressMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.43
+  SINGLE-VALUE X-ORIGIN 'RFC 2256' )
+attributeTypes: ( 2.5.4.30 NAME 'supportedApplicationContext'
+  EQUALITY objectIdentifierMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.38
+  X-ORIGIN 'RFC 2256' )
+attributeTypes: ( 2.5.4.31 NAME 'member' SUP distinguishedName
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.32 NAME 'owner' SUP distinguishedName
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.33 NAME 'roleOccupant' SUP distinguishedName
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.34 NAME 'seeAlso' SUP distinguishedName
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.35 NAME 'userPassword'
+  SYNTAX 1.3.6.1.4.1.26027.1.3.1 X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.36 NAME 'userCertificate'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.8 X-ORIGIN 'RFC 4523' )
+attributeTypes: ( 2.5.4.37 NAME 'cACertificate'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.8 X-ORIGIN 'RFC 4523' )
+attributeTypes: ( 2.5.4.38 NAME 'authorityRevocationList'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.9 X-ORIGIN 'RFC 4523' )
+attributeTypes: ( 2.5.4.39 NAME 'certificateRevocationList'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.9 X-ORIGIN 'RFC 4523' )
+attributeTypes: ( 2.5.4.40 NAME 'crossCertificatePair'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.10 X-ORIGIN 'RFC 4523' )
+attributeTypes: ( 2.5.4.42 NAME 'givenName' SUP name X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.43 NAME 'initials' SUP name X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.44 NAME 'generationQualifier' SUP name
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.45 NAME 'x500UniqueIdentifier' EQUALITY bitStringMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.6 X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.46 NAME 'dnQualifier' EQUALITY caseIgnoreMatch
+  ORDERING caseIgnoreOrderingMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.44 X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.47 NAME 'enhancedSearchGuide'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.21 X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 1.3.6.1.1.16.4 NAME 'entryUUID'
+  DESC 'UUID of the entry' EQUALITY uuidMatch ORDERING uuidOrderingMatch
+  SYNTAX 1.3.6.1.1.16.1 SINGLE-VALUE NO-USER-MODIFICATION
+  USAGE directoryOperation X-ORIGIN 'RFC 4530' )
+attributeTypes: ( 2.5.4.48 NAME 'protocolInformation'
+  EQUALITY protocolInformationMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.42
+  X-ORIGIN 'RFC 2256' )
+attributeTypes: ( 2.5.4.50 NAME 'uniqueMember' EQUALITY uniqueMemberMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.34 X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 1.3.6.1.4.1.26027.1.1.585 NAME 'lastExternalChangelogCookie'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 X-ORIGIN 'OpenDS Directory Node' )
+attributeTypes: ( 1.3.6.1.4.1.26027.1.1.593 NAME 'firstChangeNumber'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 X-ORIGIN 'OpenDS Directory Node' )
+attributeTypes: ( 1.3.6.1.4.1.26027.1.1.594 NAME 'lastChangeNumber'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 X-ORIGIN 'OpenDS Directory Node' )
+attributeTypes: ( 2.5.4.51 NAME 'houseIdentifier' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{32768}
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.52 NAME 'supportedAlgorithms'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.49 X-ORIGIN 'RFC 4523' )
+attributeTypes: ( 2.5.4.53 NAME 'deltaRevocationList'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.9 X-ORIGIN 'RFC 4523' )
+attributeTypes: ( 2.5.4.54 NAME 'dmdName' SUP name X-ORIGIN 'RFC 2256' )
+attributeTypes: ( 2.5.18.1 NAME 'createTimestamp' EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.18.2 NAME 'modifyTimestamp' EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.18.3 NAME 'creatorsName' EQUALITY distinguishedNameMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 SINGLE-VALUE NO-USER-MODIFICATION
+  USAGE directoryOperation X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.18.4 NAME 'modifiersName' EQUALITY distinguishedNameMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 SINGLE-VALUE NO-USER-MODIFICATION
+  USAGE directoryOperation X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.18.9 NAME 'hasSubordinates' EQUALITY booleanMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE NO-USER-MODIFICATION
+  USAGE directoryOperation X-ORIGIN 'X.501' )
+attributeTypes: ( 2.5.18.10 NAME 'subschemaSubentry'
+  EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.21.5 NAME 'attributeTypes' EQUALITY caseIgnoreMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.3 USAGE directoryOperation
+  X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.21.6 NAME 'objectClasses' EQUALITY caseIgnoreMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.37 USAGE directoryOperation
+  X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.21.4 NAME 'matchingRules' EQUALITY caseIgnoreMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.30 USAGE directoryOperation
+  X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.21.8 NAME 'matchingRuleUse' EQUALITY caseIgnoreMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.31 USAGE directoryOperation
+  X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.21.9 NAME 'structuralObjectClass' EQUALITY objectIdentifierMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.38 SINGLE-VALUE NO-USER-MODIFICATION
+  USAGE directoryOperation X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.21.10 NAME 'governingStructureRule' EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE NO-USER-MODIFICATION
+  USAGE directoryOperation X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 1.3.6.1.4.1.1466.101.120.5 NAME 'namingContexts'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 USAGE dSAOperation X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 1.3.6.1.4.1.1466.101.120.6 NAME 'altNode'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 USAGE dSAOperation X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 1.3.6.1.4.1.1466.101.120.7 NAME 'supportedExtension'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.38 USAGE dSAOperation X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 1.3.6.1.4.1.1466.101.120.13 NAME 'supportedControl'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.38 USAGE dSAOperation X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 1.3.6.1.4.1.1466.101.120.14 NAME 'supportedSASLMechanisms'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 USAGE dSAOperation X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 1.3.6.1.4.1.1466.101.120.15 NAME 'supportedLDAPVersion'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 USAGE dSAOperation X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 1.3.6.1.4.1.4203.1.3.5 NAME 'supportedFeatures'
+  EQUALITY objectIdentifierMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.38
+  USAGE dSAOperation X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 1.3.6.1.4.1.1466.101.120.16 NAME 'ldapSyntaxes'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.54 USAGE directoryOperation
+  X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.21.1 NAME 'dITStructureRules' EQUALITY caseIgnoreMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.17 USAGE directoryOperation
+  X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.21.7 NAME 'nameForms' EQUALITY caseIgnoreMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.35 USAGE directoryOperation
+  X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.21.2 NAME 'dITContentRules' EQUALITY caseIgnoreMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.16 USAGE directoryOperation
+  X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 0.9.2342.19200300.100.1.25 NAME ( 'dc' 'domainComponent' )
+  EQUALITY caseIgnoreIA5Match SUBSTR caseIgnoreIA5SubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.16.840.1.113730.3.1.1 NAME 'carLicense'
+  DESC 'vehicle license or registration plate' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  X-ORIGIN 'RFC 2798' )
+attributeTypes: ( 2.16.840.1.113730.3.1.2 NAME 'departmentNumber'
+  DESC 'identifies a department within an organization'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'RFC 2798' )
+attributeTypes: ( 2.16.840.1.113730.3.1.241 NAME 'displayName'
+  DESC 'preferred name of a person to be used when displaying entries'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'RFC 2798' )
+attributeTypes: ( 2.16.840.1.113730.3.1.3 NAME 'employeeNumber'
+  DESC 'numerically identifies an employee within an organization'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'RFC 2798' )
+attributeTypes: ( 2.16.840.1.113730.3.1.4 NAME 'employeeType'
+  DESC 'type of employment for a person' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  X-ORIGIN 'RFC 2798' )
+attributeTypes: ( 0.9.2342.19200300.100.1.60 NAME 'jpegPhoto'
+  DESC 'a JPEG image' SYNTAX 1.3.6.1.4.1.1466.115.121.1.28
+  X-ORIGIN 'RFC 2798' )
+attributeTypes: ( 2.16.840.1.113730.3.1.39 NAME 'preferredLanguage'
+  DESC 'preferred written or spoken language for a person'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'RFC 2798' )
+attributeTypes: ( 2.16.840.1.113730.3.1.40 NAME 'userSMIMECertificate'
+  DESC 'PKCS#7 SignedData used to support S/MIME'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.5 X-ORIGIN 'RFC 2798' )
+attributeTypes: ( 2.16.840.1.113730.3.1.216 NAME 'userPKCS12'
+  DESC 'PKCS #12 PFX PDU for exchange of personal identity information'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.5 X-ORIGIN 'RFC 2798' )
+attributeTypes: ( 0.9.2342.19200300.100.1.37 NAME 'associatedDomain'
+  EQUALITY caseIgnoreIA5Match SUBSTR caseIgnoreIA5SubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.38 NAME 'associatedName'
+  EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.48 NAME 'buildingName'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.43 NAME ( 'co' 'friendlyCountryName' )
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.14 NAME 'documentAuthor'
+  EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.11 NAME 'documentIdentifier'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.15 NAME 'documentLocation'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.56 NAME 'documentPublisher'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.12 NAME 'documentTitle'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.13 NAME 'documentVersion'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.5 NAME ( 'drink' 'favouriteDrink' )
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.20
+  NAME ( 'homePhone' 'homeTelephoneNumber' ) EQUALITY telephoneNumberMatch
+  SUBSTR telephoneNumberSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.50
+  X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.39 NAME 'homePostalAddress'
+  EQUALITY caseIgnoreListMatch SUBSTR caseIgnoreListSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.41 X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.9 NAME 'host' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256}
+  X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.4 NAME 'info' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{2048}
+  X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.3 NAME ( 'mail' 'rfc822Mailbox' )
+  EQUALITY caseIgnoreIA5Match SUBSTR caseIgnoreIA5SubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.10 NAME 'manager'
+  EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.41
+  NAME ( 'mobile' 'mobileTelephoneNumber' ) EQUALITY telephoneNumberMatch
+  SUBSTR telephoneNumberSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.50
+  X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.45 NAME 'organizationalStatus'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.42
+  NAME ( 'pager' 'pagerTelephoneNumber' ) EQUALITY telephoneNumberMatch
+  SUBSTR telephoneNumberSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.50
+  X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.40 NAME 'personalTitle'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.6 NAME 'roomNumber'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.21 NAME 'secretary'
+  EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.44 NAME 'uniqueIdentifier'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.8 NAME 'userClass'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 1.3.6.1.4.1.250.1.57 NAME 'labeledURI'
+  DESC 'Uniform Resource Identifier with optional label'
+  EQUALITY caseExactMatch SUBSTR caseExactSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'RFC 2079' )
+attributeTypes: ( 1.3.6.1.4.1.250.1.41 NAME 'labeledURL'
+  DESC 'Uniform Resource Locator with optional label'
+  EQUALITY caseExactMatch SUBSTR caseExactSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'RFC 2079' )
+attributeTypes: ( 0.9.2342.19200300.100.1.55 NAME 'audio'
+  EQUALITY octetStringMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.40{250000}
+  X-ORIGIN 'RFC 2798' )
+attributeTypes: ( 0.9.2342.19200300.100.1.7 NAME 'photo'
+  EQUALITY octetStringMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+  X-ORIGIN 'RFC 2798' )
+attributeTypes: ( 0.9.2342.19200300.100.1.1 NAME ( 'uid' 'userid' )
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 1.3.6.1.1.4 NAME 'vendorName'
+  EQUALITY 1.3.6.1.4.1.1466.109.114.1 SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE dSAOperation X-ORIGIN 'RFC 3045' )
+attributeTypes: ( 1.3.6.1.1.5 NAME 'vendorVersion'
+  EQUALITY 1.3.6.1.4.1.1466.109.114.1 SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE dSAOperation X-ORIGIN 'RFC 3045' )
+attributeTypes: ( 2.16.840.1.113730.3.1.34 NAME 'ref'
+  DESC 'named reference - a labeledURI' EQUALITY caseExactMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 USAGE distributedOperation
+  X-ORIGIN 'RFC 3296' )
+attributeTypes: ( 1.3.6.1.4.1.7628.5.4.1 NAME 'inheritable'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE NO-USER-MODIFICATION
+  USAGE dSAOperation X-ORIGIN 'draft-ietf-ldup-subentry' )
+attributeTypes: ( 1.3.6.1.4.1.7628.5.4.2 NAME 'blockInheritance'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE NO-USER-MODIFICATION
+  USAGE dSAOperation X-ORIGIN 'draft-ietf-ldup-subentry' )
+attributeTypes: ( 2.16.840.1.113730.3.1.55 NAME 'aci'
+  DESC 'Sun-defined access control information attribute type'
+  EQUALITY octetStringMatch
+  SYNTAX 1.3.6.1.4.1.26027.1.3.4 USAGE directoryOperation
+  X-ORIGIN 'Sun Java System Directory Node' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.9.1.39 NAME 'aclRights'
+  DESC 'Sun-defined access control effective rights attribute type'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'Sun Java System Directory Node' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.9.1.40 NAME 'aclRightsInfo'
+  DESC 'Sun-defined access control effective rights information attribute type'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'Sun Java System Directory Node' )
+attributeTypes: ( 2.16.840.1.113730.3.1.542 NAME 'nsUniqueId'
+  DESC 'Sun-defined unique identifier' SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'Sun Java System Directory Node' )
+attributeTypes: ( 1.3.6.1.4.1.1466.101.120.1 NAME 'administratorsAddress'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 USAGE directoryOperation
+  X-ORIGIN 'draft-wahl-ldap-adminaddr' )
+attributeTypes: ( 2.16.840.1.113730.3.1.198 NAME 'memberURL'
+  DESC 'Sun-defined attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  X-ORIGIN 'Sun Java System Directory Node' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.9.1.792 NAME 'isMemberOf'
+  DESC 'Sun-defined attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'Sun Java System Directory Node' )
+attributeTypes: ( 0.9.2342.19200300.100.1.54 NAME 'dITRedirect'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.49 NAME 'dSAQuality'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.46 NAME 'janetMailbox'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.24 NAME 'lastModifiedBy'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.23 NAME 'lastModifiedTime'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.47 NAME 'mailPreferenceOption'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.53 NAME 'personalSignature'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.5 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.50 NAME 'singleLevelQuality'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.51 NAME 'subtreeMinimumQuality'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.52 NAME 'subtreeMaximumQuality'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.2 NAME 'textEncodedORAddress'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.22 NAME 'otherMailbox'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.26 NAME 'aRecord'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.27 NAME 'mDRecord'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.28 NAME 'mxRecord'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.29 NAME 'nSRecord'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.30 NAME 'sOARecord'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.31 NAME 'cNAMERecord'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 1.3.6.1.1.20 NAME 'entryDN' DESC 'DN of the entry'
+  EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'RFC 5020' )
+attributeTypes: ( 1.3.6.1.4.1.453.16.2.103 NAME 'numSubordinates'
+  DESC 'Count of immediate subordinates'
+  EQUALITY integerMatch ORDERING integerOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'draft-ietf-boreham-numsubordinates' )
+attributeTypes: ( 2.16.840.1.113730.3.1.35 NAME 'changelog' 
+  DESC 'the distinguished name of the entry which contains
+  the set of entries comprising this server's changelog'
+  EQUALITY distinguishedNameMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'draft-good-ldap-changelog' )
+objectClasses: ( 2.5.6.0 NAME 'top' ABSTRACT MUST objectClass
+  X-ORIGIN 'RFC 4512' )
+objectClasses: ( 2.5.6.1 NAME 'alias' SUP top STRUCTURAL MUST aliasedObjectName
+  X-ORIGIN 'RFC 4512' )
+objectClasses: ( 2.5.6.2 NAME 'country' SUP top STRUCTURAL MUST c
+  MAY ( searchGuide $ description ) X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.3 NAME 'locality' SUP top STRUCTURAL
+  MAY ( street $ seeAlso $ searchGuide $ st $ l $ description )
+  X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.4 NAME 'organization' SUP top STRUCTURAL MUST o
+  MAY ( userPassword $ searchGuide $ seeAlso $ businessCategory $ x121Address $
+  registeredAddress $ destinationIndicator $ preferredDeliveryMethod $
+  telexNumber $ teletexTerminalIdentifier $ telephoneNumber $
+  internationaliSDNNumber $ facsimileTelephoneNumber $ street $ postOfficeBox $
+  postalCode $ postalAddress $ physicalDeliveryOfficeName $ st $ l $
+  description ) X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.5 NAME 'organizationalUnit' SUP top STRUCTURAL MUST ou
+  MAY ( userPassword $ searchGuide $ seeAlso $ businessCategory $ x121Address $
+  registeredAddress $ destinationIndicator $ preferredDeliveryMethod $
+  telexNumber $ teletexTerminalIdentifier $ telephoneNumber $
+  internationaliSDNNumber $ facsimileTelephoneNumber $ street $ postOfficeBox $
+  postalCode $ postalAddress $ physicalDeliveryOfficeName $ st $ l $
+  description ) X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.6 NAME 'person' SUP top STRUCTURAL MUST ( sn $ cn )
+  MAY ( userPassword $ telephoneNumber $ seeAlso $ description )
+  X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.7 NAME 'organizationalPerson' SUP person STRUCTURAL
+  MAY ( title $ x121Address $ registeredAddress $ destinationIndicator $
+  preferredDeliveryMethod $ telexNumber $ teletexTerminalIdentifier $
+  telephoneNumber $ internationaliSDNNumber $ facsimileTelephoneNumber $
+  street $ postOfficeBox $ postalCode $ postalAddress $
+  physicalDeliveryOfficeName $ ou $ st $ l ) X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.8 NAME 'organizationalRole' SUP top STRUCTURAL MUST cn
+  MAY ( x121Address $ registeredAddress $ destinationIndicator $
+  preferredDeliveryMethod $ telexNumber $ teletexTerminalIdentifier $
+  telephoneNumber $ internationaliSDNNumber $ facsimileTelephoneNumber $
+  seeAlso $ roleOccupant $ preferredDeliveryMethod $ street $ postOfficeBox $
+  postalCode $ postalAddress $ physicalDeliveryOfficeName $ ou $ st $ l $
+  description ) X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.9 NAME 'groupOfNames' SUP top STRUCTURAL
+  MUST cn MAY ( member $ businessCategory $ seeAlso $ owner $ ou $ o $
+  description ) X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.10 NAME 'residentialPerson' SUP person STRUCTURAL MUST l
+  MAY ( businessCategory $ x121Address $ registeredAddress $
+  destinationIndicator $ preferredDeliveryMethod $ telexNumber $
+  teletexTerminalIdentifier $ telephoneNumber $ internationaliSDNNumber $
+  facsimileTelephoneNumber $ street $ postOfficeBox $ postalCode $
+  postalAddress $ physicalDeliveryOfficeName $ st ) X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.11 NAME 'applicationProcess' SUP top STRUCTURAL MUST cn
+  MAY ( seeAlso $ ou $ l $ description ) X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.12 NAME 'applicationEntity' SUP top STRUCTURAL
+  MUST ( presentationAddress $ cn ) MAY ( supportedApplicationContext $
+  seeAlso $ ou $ o $ l $ description ) X-ORIGIN 'RFC 2256' )
+objectClasses: ( 2.5.6.13 NAME 'dSA' SUP applicationEntity STRUCTURAL
+  MAY knowledgeInformation X-ORIGIN 'RFC 2256' )
+objectClasses: ( 2.5.6.14 NAME 'device' SUP top STRUCTURAL MUST cn
+  MAY ( serialNumber $ seeAlso $ owner $ ou $ o $ l $ description )
+  X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.15 NAME 'strongAuthenticationUser' SUP top AUXILIARY
+  MUST userCertificate X-ORIGIN 'RFC 4523' )
+objectClasses: ( 2.5.6.16 NAME 'certificationAuthority' SUP top AUXILIARY
+  MUST ( authorityRevocationList $ certificateRevocationList $ caCertificate )
+  MAY crossCertificatePair X-ORIGIN 'RFC 4523' )
+objectClasses: ( 2.5.6.16.2 NAME 'certificationAuthority-V2'
+  SUP certificationAuthority AUXILIARY MAY deltaRevocationList
+  X-ORIGIN 'RFC 4523' )
+objectClasses: ( 2.5.6.17 NAME 'groupOfUniqueNames' SUP top STRUCTURAL
+  MUST cn MAY ( uniqueMember $ businessCategory $ seeAlso $ owner $ ou $ o $
+  description ) X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.18 NAME 'userSecurityInformation' SUP top AUXILIARY
+  MAY ( supportedAlgorithms ) X-ORIGIN 'RFC 4523' )
+objectClasses: ( 2.5.6.19 NAME 'cRLDistributionPoint' SUP top STRUCTURAL
+  MUST cn MAY ( certificateRevocationList $ authorityRevocationList $
+  deltaRevocationList ) X-ORIGIN 'RFC 4523' )
+objectClasses: ( 2.5.6.20 NAME 'dmd' SUP top STRUCTURAL MUST dmdName
+  MAY ( userPassword $ searchGuide $ seeAlso $ businessCategory $ x121Address $
+  registeredAddress $ destinationIndicator $ preferredDeliveryMethod $
+  telexNumber $ teletexTerminalIdentifier $ telephoneNumber $
+  internationaliSDNNumber $ facsimileTelephoneNumber $ street $ postOfficeBox $
+  postalCode $ postalAddress $ physicalDeliveryOfficeName $ st $ l $
+  description ) X-ORIGIN 'RFC 2256' )
+objectClasses: ( 1.3.6.1.4.1.1466.101.120.111 NAME 'extensibleObject' SUP top
+  AUXILIARY X-ORIGIN 'RFC 4512' )
+objectClasses: ( 2.5.20.1 NAME 'subschema' AUXILIARY MAY ( dITStructureRules $
+  nameForms $ ditContentRules $ objectClasses $ attributeTypes $ matchingRules $
+  matchingRuleUse ) X-ORIGIN 'RFC 4512' )
+objectClasses: ( 0.9.2342.19200300.100.4.5 NAME 'account' SUP top STRUCTURAL
+  MUST uid MAY ( description $ seeAlso $ l $ o $ ou $ host )
+  X-ORIGIN 'RFC 4524' )
+objectClasses: ( 0.9.2342.19200300.100.4.6 NAME 'document' SUP top STRUCTURAL
+  MUST documentIdentifier MAY ( cn $ description $ seeAlso $ l $ o $ ou $
+  documentTitle $ documentVersion $ documentAuthor $ documentLocation $
+  documentPublisher ) X-ORIGIN 'RFC 4524' )
+objectClasses: ( 0.9.2342.19200300.100.4.9 NAME 'documentSeries' SUP top
+  STRUCTURAL MUST cn MAY ( description $ l $ o $ ou $ seeAlso $
+  telephoneNumber ) X-ORIGIN 'RFC 4524' )
+objectClasses: ( 0.9.2342.19200300.100.4.13 NAME 'domain' SUP top STRUCTURAL
+  MUST dc MAY ( userPassword $ searchGuide $ seeAlso $ businessCategory $
+  x121Address $ registeredAddress $ destinationIndicator $
+  preferredDeliveryMethod $ telexNumber $ teletexTerminalIdentifier $
+  telephoneNumber $ internationaliSDNNumber $ facsimileTelephoneNumber $
+  street $ postOfficeBox $ postalCode $ postalAddress $
+  physicalDeliveryOfficeName $ st $ l $ description $ o $ associatedName )
+  X-ORIGIN 'RFC 4524' )
+objectClasses: ( 0.9.2342.19200300.100.4.17 NAME 'domainRelatedObject' SUP top
+  AUXILIARY MUST associatedDomain X-ORIGIN 'RFC 4524' )
+objectClasses: ( 0.9.2342.19200300.100.4.18 NAME 'friendlyCountry' SUP country
+  STRUCTURAL MUST co X-ORIGIN 'RFC 4524' )
+objectClasses: ( 0.9.2342.19200300.100.4.14 NAME 'rFC822LocalPart' SUP domain
+  STRUCTURAL MAY ( cn $ description $ destinationIndicator $
+  facsimileTelephoneNumber $ internationaliSDNNumber $
+  physicalDeliveryOfficeName $ postalAddress $ postalCode $ postOfficeBox $
+  preferredDeliveryMethod $ registeredAddress $ seeAlso $ sn $ street $
+  telephoneNumber $ teletexTerminalIdentifier $ telexNumber $ x121Address )
+  X-ORIGIN 'RFC 4524' )
+objectClasses: ( 0.9.2342.19200300.100.4.7 NAME 'room' SUP top STRUCTURAL
+  MUST cn MAY ( roomNumber $ description $ seeAlso $ telephoneNumber )
+  X-ORIGIN 'RFC 4524' )
+objectClasses: ( 0.9.2342.19200300.100.4.19 NAME 'simpleSecurityObject' SUP top
+  AUXILIARY MUST userPassword X-ORIGIN 'RFC 4524' )
+objectClasses: ( 1.3.6.1.4.1.1466.344 NAME 'dcObject' SUP top AUXILIARY MUST dc
+  X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.16.840.1.113730.3.2.2 NAME 'inetOrgPerson'
+  SUP organizationalPerson STRUCTURAL MAY ( audio $ businessCategory $
+  carLicense $ departmentNumber $ displayName $ employeeNumber $ employeeType $
+  givenName $ homePhone $ homePostalAddress $ initials $ jpegPhoto $
+  labeledURI $ mail $ manager $ mobile $ o $ pager $ photo $ roomNumber $
+  secretary $ uid $ userCertificate $ x500UniqueIdentifier $
+  preferredLanguage $ userSMIMECertificate $ userPKCS12 ) X-ORIGIN 'RFC 2798' )
+objectClasses: ( 1.3.6.1.4.1.250.3.15 NAME 'labeledURIObject'
+  DESC 'object that contains the URI attribute type' SUP top AUXILIARY
+  MAY labeledURI X-ORIGIN 'RFC 2079' )
+objectClasses: ( 1.3.6.1.4.1.5322.13.1.1 NAME 'namedObject' SUP top STRUCTURAL
+  MAY cn X-ORIGIN 'draft-howard-namedobject' )
+objectClasses: ( 1.3.6.1.4.1.26027.1.2.900 NAME 'untypedObject'
+  DESC 'Entry of no particular type' SUP top STRUCTURAL MAY ( c $ cn $ dc $ l $
+  o $ ou $ st $ street $ uid $ description $ owner $ seeAlso )
+  X-ORIGIN 'draft-furuseth-ldap-untypedobject' )
+objectClasses: ( 1.3.6.1.1.3.1 NAME 'uidObject' SUP top AUXILIARY MUST uid
+  X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.16.840.1.113730.3.2.6 NAME 'referral'
+  DESC 'named subordinate reference object' STRUCTURAL MUST ref
+  X-ORIGIN 'RFC 3296' )
+objectClasses: ( 2.16.840.1.113719.2.142.6.1.1 NAME 'ldapSubEntry'
+  DESC 'LDAP Subentry class, version 1'  SUP top STRUCTURAL  MAY ( cn )
+  X-ORIGIN 'draft-ietf-ldup-subentry' )
+objectClasses: ( 1.3.6.1.4.1.7628.5.6.1.1 NAME 'inheritableLDAPSubEntry'
+  DESC 'Inheritable LDAP Subentry class, version 1'  SUP ldapSubEntry
+  STRUCTURAL  MUST ( inheritable )  MAY  ( blockInheritance )
+  X-ORIGIN 'draft-ietf-ldup-subentry' )
+objectClasses: ( 2.16.840.1.113730.3.2.33 NAME 'groupOfURLs'
+  DESC 'Sun-defined objectclass' SUP top STRUCTURAL MUST ( cn )
+  MAY ( memberURL $ businessCategory $ description $ o $ ou $ owner $ seeAlso )
+  X-ORIGIN 'Sun Java System Directory Node' )
+objectClasses: ( 0.9.2342.19200300.100.4.3 NAME 'pilotObject'
+  SUP top MAY ( audio $ dITRedirect $ info $ jpegPhoto $ lastModifiedBy $
+  lastModifiedTime $ manager $ photo $ uniqueIdentifier ) X-ORIGIN 'RFC 1274' )
+objectClasses: ( 0.9.2342.19200300.100.4.4 NAME 'pilotPerson'
+  SUP person MAY ( userid $ textEncodedORAddress $ rfc822Mailbox $
+  favouriteDrink $ roomNumber $ userClass $ homeTelephoneNumber $
+  homePostalAddress $ secretary $ personalTitle $ preferredDeliveryMethod $
+  businessCategory $ janetMailbox $ otherMailbox $ mobileTelephoneNumber $
+  pagerTelephoneNumber $ organizationalStatus $ mailPreferenceOption $
+  personalSignature ) X-ORIGIN 'RFC 1274' )
+objectClasses: ( 0.9.2342.19200300.100.4.20 NAME 'pilotOrganization' SUP top
+  MUST ( ou $ o ) MAY ( buildingName $ businessCategory $ description $
+  destinationIndicator $ facsimileTelephoneNumber $ internationaliSDNNumber $
+  l $ physicalDeliveryOfficeName $ postOfficeBox $ postalAddress $ postalCode $
+  preferredDeliveryMethod $ registeredAddress $ searchGuide $ seeAlso $ st $
+  street $ telephoneNumber $ teletexTerminalIdentifier $ telexNumber $
+  userPassword $ x121Address ) X-ORIGIN 'RFC 1274' )
+objectClasses: ( 0.9.2342.19200300.100.4.15 NAME 'dNSDomain' SUP domain
+  MAY ( ARecord $ MDRecord $ MXRecord $ NSRecord $ SOARecord $ CNAMERecord )
+  X-ORIGIN 'RFC 1274' )
+objectClasses: ( 0.9.2342.19200300.100.4.21 NAME 'pilotDSA' SUP dSA
+  MUST dSAQuality X-ORIGIN 'RFC 1274' )
+objectClasses: ( 0.9.2342.19200300.100.4.22 NAME 'qualityLabelledData' SUP top
+  MUST dSAQuality MAY ( subtreeMinimumQuality $ subtreeMaximumQuality )
+  X-ORIGIN 'RFC 1274' )
+objectClasses: ( 1.2.826.0.1.3458854.2.1.1 NAME 'groupOfEntries' SUP top
+  STRUCTURAL MUST cn MAY ( member $ businessCategory $ seeAlso $ owner $ ou $
+  o $ description ) X-ORIGIN 'draft-findlay-ldap-groupofentries' )
+

--- a/inventory-repository/src/test/resources/ldap-data/schema/01-pwpolicy.ldif
+++ b/inventory-repository/src/test/resources/ldap-data/schema/01-pwpolicy.ldif
@@ -1,0 +1,118 @@
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at
+# trunk/opends/resource/legal-notices/OpenDS.LICENSE
+# or https://OpenDS.dev.java.net/OpenDS.LICENSE.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at
+# trunk/opends/resource/legal-notices/OpenDS.LICENSE.  If applicable,
+# add the following below this CDDL HEADER, with the fields enclosed
+# by brackets "[]" replaced with your own identifying information:
+#      Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+#      Copyright 2006-2008 Sun Microsystems, Inc.
+#
+#
+# This file contains schema definitions from draft-behera-ldap-password-policy,
+# which defines a mechanism for storing password policy information in an LDAP
+# directory server.
+dn: cn=schema
+objectClass: top
+objectClass: ldapSubentry
+objectClass: subschema
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.1 NAME 'pwdAttribute'
+  EQUALITY objectIdentifierMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.38
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.2 NAME 'pwdMinAge'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.3 NAME 'pwdMaxAge'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.4 NAME 'pwdInHistory'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.5 NAME 'pwdCheckQuality'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.6 NAME 'pwdMinLength'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.7 NAME 'pwdExpireWarning'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.8 NAME 'pwdGraceAuthNLimit'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.9 NAME 'pwdLockout'
+  EQUALITY booleanMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.10 NAME 'pwdLockoutDuration'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.11 NAME 'pwdMaxFailure'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.12 NAME 'pwdFailureCountInterval'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.13 NAME 'pwdMustChange'
+  EQUALITY booleanMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.14 NAME 'pwdAllowUserChange'
+  EQUALITY booleanMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.15 NAME 'pwdSafeModify'
+  EQUALITY booleanMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.16 NAME 'pwdChangedTime'
+  DESC 'The time the password was last changed' EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.17 NAME 'pwdAccountLockedTime'
+  DESC 'The time an user account was locked' EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.19 NAME 'pwdFailureTime'
+  DESC 'The timestamps of the last consecutive authentication failures'
+  EQUALITY generalizedTimeMatch ORDERING generalizedTimeOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24 NO-USER-MODIFICATION
+  USAGE directoryOperation X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.20 NAME 'pwdHistory'
+  DESC 'The history of user s passwords' EQUALITY octetStringMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 NO-USER-MODIFICATION
+  USAGE directoryOperation X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.21 NAME 'pwdGraceUseTime'
+  DESC 'The timestamps of the grace authentication after the password has
+  expired' EQUALITY generalizedTimeMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.22 NAME 'pwdReset'
+  DESC 'The indication that the password has been reset' EQUALITY booleanMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE USAGE directoryOperation
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes:  ( 1.3.6.1.4.1.42.2.27.8.1.23 NAME 'pwdPolicySubentry'
+  DESC 'The pwdPolicy subentry in effect for this object'
+  EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+objectClasses: ( 1.3.6.1.4.1.42.2.27.8.2.1 NAME 'pwdPolicy' SUP top AUXILIARY
+  MUST ( pwdAttribute ) MAY ( pwdMinAge $ pwdMaxAge $ pwdInHistory $
+  pwdCheckQuality $ pwdMinLength $ pwdExpireWarning $ pwdGraceAuthNLimit $
+  pwdLockout $ pwdLockoutDuration $ pwdMaxFailure $ pwdFailureCountInterval $
+  pwdMustChange $ pwdAllowUserChange $ pwdSafeModify )
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+

--- a/inventory-repository/src/test/resources/ldap-data/schema/04-rfc2307bis.ldif
+++ b/inventory-repository/src/test/resources/ldap-data/schema/04-rfc2307bis.ldif
@@ -1,0 +1,216 @@
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at
+# trunk/opends/resource/legal-notices/OpenDS.LICENSE
+# or https://OpenDS.dev.java.net/OpenDS.LICENSE.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at
+# trunk/opends/resource/legal-notices/OpenDS.LICENSE.  If applicable,
+# add the following below this CDDL HEADER, with the fields enclosed
+# by brackets "[]" replaced with your own identifying information:
+#      Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+#      Copyright 2006-2008 Sun Microsystems, Inc.
+#
+#
+# This file contains schema definitions from the draft-howard-rfc2307bis
+# specification, used to store naming service information in the Directory
+# Node.
+dn: cn=schema
+objectClass: top
+objectClass: ldapSubentry
+objectClass: subschema
+attributeTypes: ( 1.3.6.1.1.1.1.0 NAME 'uidNumber'
+  DESC 'An integer uniquely identifying a user in an administrative domain'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.1 NAME 'gidNumber'
+  DESC 'An integer uniquely identifying a group in an administrative domain'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.2 NAME 'gecos'
+  DESC 'The GECOS field; the common name' EQUALITY caseIgnoreIA5Match
+  SUBSTR caseIgnoreIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.3 NAME 'homeDirectory'
+  DESC 'The absolute path to the home directory' EQUALITY caseExactIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.4 NAME 'loginShell'
+  DESC 'The path to the login shell' EQUALITY caseExactIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.5 NAME 'shadowLastChange' EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.6 NAME 'shadowMin' EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.7 NAME 'shadowMax' EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.8 NAME 'shadowWarning' EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.9 NAME 'shadowInactive' EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.10 NAME 'shadowExpire' EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.11 NAME 'shadowFlag' EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.12 NAME 'memberUid' EQUALITY caseExactIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.13 NAME 'memberNisNetgroup'
+  EQUALITY caseExactIA5Match SUBSTR caseExactIA5SubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.14 NAME 'nisNetgroupTriple'
+  DESC 'Netgroup triple' EQUALITY caseIgnoreIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.15 NAME 'ipServicePort'
+  DESC 'Service port number' EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.16 NAME 'ipServiceProtocol'
+  DESC 'Service protocol name' SUP name X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.17 NAME 'ipProtocolNumber'
+  DESC 'IP protocol number' EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.18 NAME 'oncRpcNumber' DESC 'ONC RPC number'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.19 NAME 'ipHostNumber'
+  DESC 'IPv4 addresses as a dotted decimal omitting leading zeros or IPv6
+  addresses as defined in RFC2373' SUP name
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.20 NAME 'ipNetworkNumber'
+  DESC 'IP network as a dotted decimal, eg. 192.168, omitting leading zeros'
+  SUP name SINGLE-VALUE X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.21 NAME 'ipNetmaskNumber'
+  DESC 'IP netmask as a dotted decimal, eg. 255.255.255.0, omitting leading
+  zeros' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.22 NAME 'macAddress'
+  DESC 'MAC address in maximal, colon separated hex notation, eg.
+  00:00:92:90:ee:e2' EQUALITY caseIgnoreIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.23 NAME 'bootParameter'
+  DESC 'rpc.bootparamd parameter' EQUALITY caseExactIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.24 NAME 'bootFile' DESC 'Boot image name'
+  EQUALITY caseExactIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.26 NAME 'nisMapName'
+  DESC 'Name of a A generic NIS map' SUP name
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.27 NAME 'nisMapEntry'
+  DESC 'A generic NIS entry' EQUALITY caseExactIA5Match
+  SUBSTR caseExactIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.28 NAME 'nisPublicKey' DESC 'NIS public key'
+  EQUALITY octetStringMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.29 NAME 'nisSecretKey' DESC 'NIS secret key'
+  EQUALITY octetStringMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.30 NAME 'nisDomain' DESC 'NIS domain'
+  EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.31 NAME 'automountMapName'
+  DESC 'automount Map Name' EQUALITY caseExactIA5Match
+  SUBSTR caseExactIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.32 NAME 'automountKey'
+  DESC 'Automount Key value' EQUALITY caseExactIA5Match
+  SUBSTR caseExactIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.33 NAME 'automountInformation'
+  DESC 'Automount information' EQUALITY caseExactIA5Match
+  SUBSTR caseExactIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.0 NAME 'posixAccount' SUP top AUXILIARY
+  DESC 'Abstraction of an account with POSIX attributes'
+  MUST ( cn $ uid $ uidNumber $ gidNumber $ homeDirectory )
+  MAY ( authPassword $ userPassword $ loginShell $ gecos $ description )
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.1 NAME 'shadowAccount' SUP top AUXILIARY
+  DESC 'Additional attributes for shadow passwords' MUST uid
+  MAY ( authPassword $ userPassword $ description $ shadowLastChange $
+  shadowMin $ shadowMax $ shadowWarning $ shadowInactive $ shadowExpire $
+  shadowFlag ) X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.2 NAME 'posixGroup' SUP top AUXILIARY
+  DESC 'Abstraction of a group of accounts' MUST gidNumber
+  MAY ( authPassword $ userPassword $ memberUid $ description )
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.3 NAME 'ipService' SUP top STRUCTURAL
+  DESC 'Abstraction an Internet Protocol service.  Maps an IP port and protocol
+  (such as tcp or udp) to one or more names; the distinguished value of the cn
+  attribute denotes the canonical name of the service'
+  MUST ( cn $ ipServicePort $ ipServiceProtocol ) MAY description
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.4 NAME 'ipProtocol' SUP top STRUCTURAL
+  DESC 'Abstraction of an IP protocol. Maps a protocol number to one or more
+  names. The distinguished value of the cn attribute denotes the canonical name
+  of the protocol' MUST ( cn $ ipProtocolNumber ) MAY description
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.5 NAME 'oncRpc' SUP top STRUCTURAL
+  DESC 'Abstraction of an Open Network Computing (ONC) [RFC1057] Remote
+  Procedure Call (RPC) binding.  This class maps an ONC RPC number to a name.
+  The distinguished value of the cn attribute denotes the canonical name of the
+  RPC service' MUST ( cn $ oncRpcNumber ) MAY description
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.6 NAME 'ipHost' SUP top AUXILIARY
+  DESC 'Abstraction of a host, an IP device. The distinguished value of the cn
+  attribute denotes the canonical name of the host. Device SHOULD be used as a
+  structural class' MUST ( cn $ ipHostNumber )
+  MAY ( authPassword $ userPassword $ l $ description $ manager )
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.7 NAME 'ipNetwork' SUP top STRUCTURAL
+  DESC 'Abstraction of a network. The distinguished value of the cn attribute
+  denotes the canonical name of the network' MUST ipNetworkNumber
+  MAY ( cn $ ipNetmaskNumber $ l $ description $ manager )
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.8 NAME 'nisNetgroup' SUP top STRUCTURAL
+  DESC 'Abstraction of a netgroup. May refer to other netgroups' MUST cn
+  MAY ( nisNetgroupTriple $ memberNisNetgroup $ description )
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.9 NAME 'nisMap' SUP top STRUCTURAL
+  DESC 'A generic abstraction of a NIS map' MUST nisMapName MAY description
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.10 NAME 'nisObject' SUP top STRUCTURAL
+  DESC 'An entry in a NIS map' MUST ( cn $ nisMapEntry $ nisMapName )
+  MAY description X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.11 NAME 'ieee802Device' SUP top AUXILIARY
+  DESC 'A device with a MAC address; device SHOULD be used as a structural
+  class' MAY macAddress X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.12 NAME 'bootableDevice' SUP top AUXILIARY
+  DESC 'A device with boot parameters; device SHOULD be used as a structural
+  class' MAY ( bootFile $ bootParameter ) X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.14 NAME 'nisKeyObject' SUP top AUXILIARY
+  DESC 'An object with a public and secret key'
+  MUST ( cn $ nisPublicKey $ nisSecretKey ) MAY ( uidNumber $ description )
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.15 NAME 'nisDomainObject' SUP top AUXILIARY
+  DESC 'Associates a NIS domain with a naming context' MUST nisDomain
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.16 NAME 'automountMap' SUP top STRUCTURAL
+  MUST ( automountMapName ) MAY description
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.17 NAME 'automount' SUP top STRUCTURAL
+  DESC 'Automount information' MUST ( automountKey $ automountInformation )
+  MAY description X-ORIGIN 'draft-howard-rfc2307bis' )
+

--- a/inventory-repository/src/test/resources/ldap-data/schema/05-rfc4876.ldif
+++ b/inventory-repository/src/test/resources/ldap-data/schema/05-rfc4876.ldif
@@ -1,0 +1,127 @@
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at
+# trunk/opends/resource/legal-notices/OpenDS.LICENSE
+# or https://OpenDS.dev.java.net/OpenDS.LICENSE.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at
+# trunk/opends/resource/legal-notices/OpenDS.LICENSE.  If applicable,
+# add the following below this CDDL HEADER, with the fields enclosed
+# by brackets "[]" replaced with your own identifying information:
+#      Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+#      Copyright 2008 Sun Microsystems, Inc.
+#
+#
+# This file contains schema definitions from RFC 4876, which defines a schema # for storing Directory User Agent (DUA) profiles and preferences in the
+# Directory Node.
+#
+# Example profile
+# dn: ou=profile,dc=example,dc=com
+# objectClass: top
+# objectClass: organizationalUnit
+# ou: profile
+# 
+# dn: cn=Solaris,ou=profile,dc=example,dc=com
+# objectClass: top
+# objectClass: DUAConfigProfile
+# cn: Solaris
+# defaultNodeList: ldap1.example.com ldap2.example.com
+# defaultSearchBase: dc=example,dc=com
+# defaultSearchScope: one
+# searchTimeLimit: 30
+# bindTimeLimit: 2
+# credentialLevel: anonymous
+# authenticationMethod: simple
+# followReferrals: TRUE
+# profileTTL: 43200
+#
+dn: cn=schema
+objectClass: top
+objectClass: ldapSubentry
+objectClass: subschema
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.0 NAME 'defaultNodeList'
+  DESC 'List of default servers' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.1 NAME 'defaultSearchBase'
+  DESC 'Default base for searches' EQUALITY distinguishedNameMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 SINGLE-VALUE X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.2 NAME 'preferredNodeList'
+  DESC 'List of preferred servers' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.3 NAME 'searchTimeLimit'
+  DESC 'Maximum time an agent or service allows for a search to complete'
+  EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX
+  1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.4 NAME 'bindTimeLimit'
+  DESC 'Maximum time an agent or service allows for a bind operation to
+  complete' EQUALITY integerMatch ORDERING integerOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.5 NAME 'followReferrals'
+  DESC 'An agent or service does or should follow referrals' EQUALITY
+  booleanMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE X-ORIGIN
+  'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.6 NAME 'authenticationMethod'
+  DESC 'Identifies the types of authentication methods either used,
+  required, or provided by a service or peer' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.7 NAME 'profileTTL'
+  DESC 'Time to live, in seconds, before a profile is considered stale'
+  EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX
+  1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.9 NAME 'attributeMap'
+  DESC 'Attribute mappings used, required, or supported by an agent or
+  service' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.10 NAME 'credentialLevel'
+  DESC 'Identifies type of credentials either used, required, or supported
+  by an agent or service' EQUALITY caseIgnoreIA5Match SYNTAX
+  1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.11 NAME 'objectclassMap'
+  DESC 'Object class mappings used, required, or supported by an agent or
+  service' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 
+  X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.12 NAME 'defaultSearchScope'
+  DESC 'Default scope used when performing a search' EQUALITY
+  caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE
+  X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.13 NAME 'serviceCredentialLevel'
+  DESC 'Specifies the type of credentials either used, required, or
+  supported by a specific service' EQUALITY caseIgnoreIA5Match SYNTAX
+  1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.14 NAME 'serviceSearchDescriptor'
+  DESC 'Specifies search descriptors required, used, or supported by a
+  particular service or agent' EQUALITY caseExactMatch SUBSTR
+  caseExactSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN
+  'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.15 NAME 'serviceAuthenticationMethod'
+  DESC 'Specifies types authentication methods either used, required, or
+  supported by a particular service' EQUALITY caseIgnoreMatch SUBSTR
+  caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN
+  'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.16 NAME 'dereferenceAliases'
+  DESC 'Specifies if a service or agent either requires, supports, or uses
+  dereferencing of aliases.' EQUALITY booleanMatch SYNTAX
+  1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE X-ORIGIN 'RFC 4876' )
+objectClasses: ( 1.3.6.1.4.1.11.1.3.1.2.5 NAME 'DUAConfigProfile'
+  SUP top STRUCTURAL DESC 'Abstraction of a base configuration for a DUA'
+  MUST ( cn ) MAY ( defaultNodeList $ preferredNodeList $
+  defaultSearchBase $ defaultSearchScope $ searchTimeLimit $ bindTimeLimit $
+  credentialLevel $ authenticationMethod $ followReferrals $
+  dereferenceAliases $ serviceSearchDescriptor $ serviceCredentialLevel $
+  serviceAuthenticationMethod $ objectclassMap $ attributeMap $ profileTTL )
+  X-ORIGIN 'RFC 4876' )

--- a/inventory-repository/src/test/resources/ldap-data/schema/099-0-inventory.ldif
+++ b/inventory-repository/src/test/resources/ldap-data/schema/099-0-inventory.ldif
@@ -1,0 +1,719 @@
+dn: cn=schema
+objectclass: top
+#*************************************************************************
+# Copyright 2011 Normation SAS
+#*************************************************************************
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#*************************************************************************
+# CMDB schema
+#
+# Depends upon core.schema, cosine.schema, nis.schema and dyngroup.schema
+# Inventory OID
+#######################################################
+################## Attributes #########################
+#######################################################
+### UUIDs ###
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.1
+  NAME 'uuid'
+  DESC 'A generic UUID'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.1.1
+  NAME 'machineId'
+  DESC 'Unique identifier for a machine'
+  SUP uuid )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.1.2
+  NAME 'nodeId'
+  DESC 'Unique identifier for a node'
+  SUP uuid )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.1.3
+  NAME 'softwareId'
+  DESC 'Unique identifier for software'
+  SUP uuid )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.1.4
+  NAME 'motherBoardUuid'
+  DESC 'Mother board UUID'
+  SUP uuid )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.1.5
+  NAME 'policyServerId'
+  DESC 'Unique identifier for the policy server of a node'
+  SUP uuid )
+#######################################################################
+#
+# Top level objects: nodes and machines. 
+#
+# A "node" is the logical part of a server. It knows
+# things like the OS, available RAM, installed software, 
+# users, network interface, file system, etc. 
+#
+# A "machine" is the physical part of a server. 
+# It contains things like CPU, memory slots, hark disk, etc
+#
+#
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.2.1
+  NAME 'node'
+  DESC 'DN of a node'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  EQUALITY distinguishedNameMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.2.2
+  NAME 'machine'
+  DESC 'DN of a machine'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  EQUALITY distinguishedNameMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.2.3
+  NAME 'hostedVm'
+  DESC 'A machine known to be an Hosted VM in a server'
+  SUP machine )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.2.4
+  NAME 'container'
+  DESC 'A machine which is the container (physical or virtual) for a server'
+  SUP machine )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.2.5
+  NAME 'software'
+  DESC 'DN of software'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  EQUALITY distinguishedNameMatch )
+#
+# A node and a machine can be composed of elements.
+#
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200
+  NAME 'elementName'
+  DESC 'Slot number of a ram chipset'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+#
+# Node information
+#
+#
+# The first information for a node is its 
+# Operating System
+#
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.100.1
+  NAME 'osName'
+  DESC 'os name of the node'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.100.2
+  NAME 'osFullName'
+  DESC 'os full name of the node'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.100.3
+  NAME 'osVersion'
+  DESC 'os version of the node'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  ORDERING caseIgnoreOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.100.4
+  NAME 'osServicePack'
+  DESC 'os service pack name of the node'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  ORDERING caseIgnoreOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.100.5
+  NAME 'osKernelVersion'
+  DESC 'kernel version of the os of the node'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  ORDERING caseIgnoreOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.100.6
+  NAME 'osArchitectureType'
+  DESC 'Details of the OS architecture (x86, x86-64, etc)'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+### windows specific information
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.100.21
+  NAME 'windowsUserDomain'
+  DESC 'User for the window system'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.100.22
+  NAME 'windowsRegistrationCompany'
+  DESC 'Company registered for that windows'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.100.23
+  NAME 'windowsKey'
+  DESC 'The registration KEY'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.100.24
+  NAME 'windowsId'
+  DESC 'The unique id of that windows instance'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+#
+# Other information for a node
+#
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.1
+  NAME 'nodeHostname'
+  DESC 'Host name of the server'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.2
+  NAME 'localAdministratorAccountName'
+  DESC 'The local administrator account name (login) on the node'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.3
+  NAME 'ram'
+  DESC 'Total RAM of the machine, in megabytes'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  EQUALITY integerMatch
+  ORDERING integerOrderingMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.4
+  NAME 'swap'
+  DESC 'Total SWAP of the machine, in megabytes'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  EQUALITY integerMatch
+  ORDERING integerOrderingMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.5
+  NAME 'localAccountName'
+  DESC 'A local account name (login) on the server'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.6
+  NAME 'lastLoggedUser'
+  DESC 'Login of the last logged user'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.7
+  NAME 'lastLoggedUserTime'
+  DESC 'Date and time of the last user login'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.8
+  NAME 'publicKey'
+  DESC 'A public key in PEM representation'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.9
+  NAME 'nodeTechniques'
+  DESC 'Name of techniques applied to that node'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.10
+  NAME 'confirmed'
+  DESC 'Flag to indicate a newly detected machine, not yet confirmed as real'
+  EQUALITY booleanMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+  SINGLE-VALUE )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.11
+  NAME 'inventoryDate'
+  DESC 'Last time an inventory was done for that element'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.12
+  NAME 'receiveDate'
+  DESC 'Last time an inventory was received for that element'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.13
+  NAME 'agentName'
+  DESC 'List of name of the agent (Nova, Community, ...)'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+#
+# A node can have some complex "logical" elements: 
+# * network interfaces
+# * file systems
+#
+### network interfaces
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.1
+  NAME 'networkInterface'
+  DESC 'Name of a network interface'
+  SUP elementName )
+### network interfaces attributes 
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.1
+  NAME 'networkInterfaceGateway'
+  DESC 'Network interface gateway address'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.2
+  NAME 'networkInterfaceDhcpServer'
+  DESC 'Network interface DHCP provider address'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.3
+  NAME 'networkInterfaceMask'
+  DESC 'Network interface subnet'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.4
+  NAME 'networkInterfaceMacAddress'
+  DESC 'Network interface MAC address'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.5
+  NAME 'networkInterfaceType'
+  DESC 'Network interface type'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.6
+  NAME 'networkInterfaceTypeMib'
+  DESC 'Network interface type mib'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+### file systems
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.2
+  NAME 'mountPoint'
+  DESC 'A mount point for a file system'
+  SUP elementName )
+### file system attributes
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.7
+  NAME 'fileCount'
+  DESC 'Number of file descriptor in the filesystem'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.8
+  NAME 'fileSystemFreeSpace'
+  DESC 'Free space in the filesystem, in megabytes'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  EQUALITY integerMatch
+  ORDERING integerOrderingMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.9
+  NAME 'fileSystemTotalSpace'
+  DESC 'Total space of the filesystem, in megabytes'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  EQUALITY integerMatch
+  ORDERING integerOrderingMatch )
+#
+# A machine can have some complex "physicale" elements: 
+# * bios
+# * controllers
+# * cpus
+# * memory slots
+# * ports
+# * slots
+# * sound cards
+# * storages (hard drives, etc)
+# * video cards
+#
+### generic attributes
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.1
+  NAME 'speed'
+  DESC 'A speed, unit should be given in the attribute value, i.e: 5400MHz'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.2
+  NAME 'status'
+  DESC 'a status'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.3
+  NAME 'model'
+  DESC 'A model version of a (physical) component'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.4
+  NAME 'quantity'
+  DESC 'Number of occurence of the element (should always be >=0'
+  EQUALITY integerMatch
+  ORDERING integerOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.5
+  NAME 'smeType'
+  DESC 'Type of a system managed element'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.6
+  NAME 'manufacturer'
+  DESC 'Builder of a physical component'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.7
+  NAME 'firmware'
+  DESC 'Firmware related information'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.8
+  NAME 'componentSerialNumber'
+  DESC 'Serial number of a physical component'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+### physical element and attributes
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.3
+  NAME 'biosName'
+  DESC 'Name of a BIOS'
+  SUP elementName )
+### controller 
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.4
+  NAME 'controllerName'
+  DESC 'Name of a controller interface'
+  SUP elementName )
+### cpu
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.5
+  NAME 'cpuName'
+  DESC 'Name of a CPU'
+  SUP elementName )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.9
+  NAME 'cpuSpeed'
+  DESC 'CPU speed, in mhz'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{16} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.10
+  NAME 'cpuStepping'
+  DESC 'Number of CPU mode to reduce speed'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{16} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.11
+  NAME 'cpuFamily'
+  DESC 'Family name of the CPU'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+### memorySlot 
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.6
+  NAME 'memorySlotNumber'
+  DESC 'Slot number of a ram chipset'
+  SUP elementName )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.12
+  NAME 'memoryCapacity'
+  DESC 'A memory capacity (ram, video, etc)'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.13
+  NAME 'memoryCaption'
+  DESC 'Information about a memory chip'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.14
+  NAME 'memorySpeed'
+  DESC 'Speed of a memory chipset'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.15
+  NAME 'memoryType'
+  DESC 'Memory type'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+### port
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.7
+  NAME 'portName'
+  DESC 'Name of a port'
+  SUP elementName )
+### slot 
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.8
+  NAME 'slotName'
+  DESC 'Name of a Slot'
+  SUP elementName )
+### sound card
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.9
+  NAME 'soundCardName'
+  DESC 'Name of a sound card'
+  SUP elementName )
+### storage 
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.10
+  NAME 'storageName'
+  DESC 'Name of a storage element (hard drive, etc)'
+  SUP elementName )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.16
+  NAME 'storageSize'
+  DESC 'The size of a storage unit'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+### video 
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.11
+  NAME 'videoCardName'
+  DESC 'Name of a video card'
+  SUP elementName )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.17
+  NAME 'videoChipset'
+  DESC 'Information '
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.18
+  NAME 'videoResolution'
+  DESC 'Max resolution for a video chipset'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+#
+# Software related information
+#
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.50
+  NAME 'releaseDate'
+  DESC 'Release date of the element'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.51
+  NAME 'licenseExpirationDate'
+  DESC 'Expiration date of the license of the element'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.52
+  NAME 'licenseName'
+  DESC 'Name of the license of the element'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.53
+  NAME 'licenseDescription'
+  DESC 'Description of the license of the element'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.54
+  NAME 'licenseProductId'
+  DESC 'Product ID of the element on whom license applies'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.55
+  NAME 'licenseProductKey'
+  DESC 'Product Key of the element on whom license applies'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.56
+  NAME 'editor'
+  DESC 'Editor (or manufacturer) of the element'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.57
+  NAME 'softwareVersion'
+  DESC 'Version of the software, for ex: v3.0.34-pre4'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+#######################################################
+################  Object Classes ######################
+#######################################################
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.0
+  NAME 'configurationRoot'
+  DESC 'The object used as root of Rudder DIT'
+  SUP top
+  STRUCTURAL
+  MUST ( cn )
+  MAY ( description ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.1
+  NAME 'machine'
+  DESC 'A container for servers, ie a physical machine or a virtual machine'
+  SUP device
+  MUST ( machineId )
+  MAY ( cn $ description $ motherBoardUuid $ confirmed $ inventoryDate $ receiveDate ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.2
+  NAME 'physicalMachine'
+  DESC 'A real, physical machine'
+  SUP top
+  AUXILIARY )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.3
+  NAME 'virtualMachine'
+  DESC 'A virtual machine'
+  SUP top
+  AUXILIARY )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.80
+  NAME 'vmWare'
+  DESC 'A VMWare VM'
+  SUP VirtualMachine
+  AUXILIARY )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.80
+  NAME 'virtualBox'
+  DESC 'A VirtualBox VM'
+  SUP VirtualMachine
+  AUXILIARY )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.80
+  NAME 'xen'
+  DESC 'A Xen VM'
+  SUP VirtualMachine
+  AUXILIARY )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.80
+  NAME 'solarisZone'
+  DESC 'A Zone in Solaris OS'
+  SUP VirtualMachine
+  AUXILIARY )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.80
+  NAME 'qemu'
+  DESC 'A Qemu VM'
+  SUP VirtualMachine
+  AUXILIARY )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.4
+  NAME 'physicalElement'
+  DESC 'A physical element, ie a component of a machine (network card, memory slots, etc)'
+  SUP top
+  ABSTRACT
+  MAY ( machineId $ machine $ description $ model $ componentSerialNumber $ firmware $
+  quantity $ smeType $ status $ manufacturer ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.5
+  NAME 'memoryPhysicalElement'
+  DESC 'A memory chipset (ram, etc)'
+  SUP physicalElement
+  STRUCTURAL
+  MUST ( memorySlotNumber )
+  MAY ( cn $ memoryCapacity $ memoryCaption $ memorySpeed $ memoryType ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.6
+  NAME 'storagePhysicalElement'
+  DESC 'A storage unit (hard disk, etc)'
+  SUP physicalElement
+  STRUCTURAL
+  MUST ( storageName )
+  MAY ( storageSize $ firmware ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.7
+  NAME 'biosPhysicalElement'
+  DESC 'A bios'
+  SUP physicalElement
+  STRUCTURAL
+  MUST ( biosName )
+  MAY ( releaseDate $ editor $ softwareVersion $ licenseExpirationDate $
+  licenseName $ licenseProductId $ licenseProductKey ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.8
+  NAME 'controllerPhysicalElement'
+  DESC 'A controller chipset'
+  SUP physicalElement
+  STRUCTURAL
+  MUST ( controllerName ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.9
+  NAME 'portPhysicalElement'
+  DESC 'A port element'
+  SUP physicalElement
+  STRUCTURAL
+  MUST ( portName ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.10
+  NAME 'processorPhysicalElement'
+  DESC 'A processor unit'
+  SUP physicalElement
+  STRUCTURAL
+  MUST ( cpuName )
+  MAY ( cpuSpeed $ cpuStepping $ cpuFamily ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.11
+  NAME 'slotPhysicalElement'
+  DESC 'A slot for external cards'
+  SUP physicalElement
+  STRUCTURAL
+  MUST ( slotName ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.12
+  NAME 'soundCardPhysicalElement'
+  DESC 'A sound card'
+  SUP physicalElement
+  STRUCTURAL
+  MUST ( soundCardName ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.13
+  NAME 'videoCardPhysicalElement'
+  DESC 'A video card'
+  SUP physicalElement
+  STRUCTURAL
+  MUST ( videoCardName )
+  MAY ( videoChipset $ videoResolution $ memoryCapacity) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.14
+  NAME 'node'
+  DESC 'A node entity. This is a logical server, such as an OS installation, may be on a virtual machine or a physical machine.'
+  SUP top
+  ABSTRACT
+  MUST ( nodeId $ localAdministratorAccountName $ nodeHostname $
+  policyServerId $ osName $ osVersion $ osKernelVersion )
+  MAY ( description $ cn $ publicKey $ agentName $ hostedVm $ container $
+  software $  localAccountName $ osServicePack $
+  nodeTechniques $ ram $ swap $ confirmed $
+  inventoryDate $ receiveDate $ ipHostNumber $ osFullName $
+  osArchitectureType $ lastLoggedUser $ lastLoggedUserTime ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.15
+  NAME 'windowsNode'
+  DESC 'A node running Microsoft Windows as an operating system'
+  SUP node
+  STRUCTURAL
+  MAY ( windowsUserDomain $ windowsRegistrationCompany $ windowsKey $ windowsId ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.16
+  NAME 'unixNode'
+  DESC 'A node running a UNIX-like operating system'
+  SUP node
+  STRUCTURAL )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.17
+  NAME 'linuxNode'
+  DESC 'A node running GNU/Linux as an operating system'
+  SUP unixNode
+  STRUCTURAL )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.18
+  NAME 'logicalElement'
+  DESC 'A logical element, ie a component of a node (network interface, file system, etc)'
+  SUP top
+  ABSTRACT
+  MAY ( nodeId $ node $ description ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.19
+  NAME 'fileSystemLogicalElement'
+  DESC 'A file system in an Operating System'
+  SUP logicalElement
+  STRUCTURAL
+  MUST ( mountPoint )
+  MAY ( cn $ fileCount $ fileSystemFreeSpace $ fileSystemTotalSpace ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.20
+  NAME 'networkInterfaceLogicalElement'
+  DESC 'A file system in an Operating System'
+  SUP logicalElement
+  STRUCTURAL
+  MUST ( networkInterface )
+  MAY ( status $ speed $ ipHostNumber $ networkInterfaceMacAddress $
+  networkInterfaceGateway $ ipNetworkNumber $ networkInterfaceDhcpServer $
+  networkInterfaceMask $ networkInterfaceType $ networkInterfaceTypeMib) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.21
+  NAME 'software'
+  DESC 'A software package'
+  SUP top
+  STRUCTURAL
+  MUST ( softwareId )
+  MAY ( cn $ description $ releaseDate $ editor $ softwareVersion $
+  licenseExpirationDate $ licenseName $ licenseProductId $ licenseProductKey ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.31
+  NAME 'dynGroup'
+  DESC 'Auxiliary objectClass to turn any entry into a dynamic group'
+  SUP top
+  AUXILIARY
+  MUST ( memberURL )
+  MAY ( description ) )

--- a/inventory-repository/src/test/scala/com/normation/inventory/ldap/core/TestInventory.scala
+++ b/inventory-repository/src/test/scala/com/normation/inventory/ldap/core/TestInventory.scala
@@ -1,0 +1,354 @@
+/*
+*************************************************************************************
+* Copyright 2011 Normation SAS
+*************************************************************************************
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU Affero GPL v3, the copyright holders add the following
+* Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU Affero GPL v3
+* licence, when you create a Related Module, this Related Module is
+* not considered as a part of the work and may be distributed under the
+* license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
+*
+*************************************************************************************
+*/
+
+package com.normation.inventory.ldap.core
+
+import org.junit.runner._
+import org.specs2.mutable._
+import org.specs2.runner._
+import com.normation.ldap.listener.InMemoryDsConnectionProvider
+import com.unboundid.ldap.sdk.{DN,ChangeType}
+import com.normation.ldap.sdk.BuildFilter
+import com.normation.inventory.domain._
+import com.normation.ldap.sdk.RwLDAPConnection
+import net.liftweb.common.Empty
+import net.liftweb.common.Full
+import net.liftweb.common.EmptyBox
+import net.liftweb.common.Box
+
+
+/**
+ * A simple test class to check that the demo data file is up to date
+ * with the schema (there may still be a desynchronization if both
+ * demo-data, test data and test schema for UnboundID are not synchronized
+ * with OpenLDAP Schema).
+ */
+@RunWith(classOf[JUnitRunner])
+class TestInventory extends Specification {
+  //needed because the in memory LDAP server is not used with connection pool
+  sequential
+
+  val schemaLDIFs = (
+      "00-core" ::
+      "01-pwpolicy" ::
+      "04-rfc2307bis" ::
+      "05-rfc4876" ::
+      "099-0-inventory" ::
+      Nil
+  ) map { name =>
+    val n = "ldap-data/schema/" + name + ".ldif"
+    val r = this.getClass.getClassLoader.getResource(n)
+    if(null == r) {
+      throw new IllegalArgumentException("Can not find ressources to load: " + n)
+    }
+    r.getPath()
+  }
+
+  val baseDN = "cn=rudder-configuration"
+
+
+  val bootstrapLDIFs = ("ldap/bootstrap.ldif" :: "ldap-data/inventory-sample-data.ldif" :: Nil) map { name =>
+    this.getClass.getClassLoader.getResource(name).getPath
+  }
+
+  val ldap = InMemoryDsConnectionProvider[RwLDAPConnection](
+      baseDNs = baseDN :: Nil
+    , schemaLDIFPaths = schemaLDIFs
+    , bootstrapLDIFPaths = bootstrapLDIFs
+  )
+
+
+  val softwareDN = new DN("ou=Inventories, cn=rudder-configuration")
+
+  val acceptedNodesDitImpl: InventoryDit = new InventoryDit(
+      new DN("ou=Accepted Inventories, ou=Inventories, cn=rudder-configuration")
+    , softwareDN
+    , "Accepted inventories"
+  )
+  val pendingNodesDitImpl: InventoryDit = new InventoryDit(
+      new DN("ou=Pending Inventories, ou=Inventories, cn=rudder-configuration")
+    , softwareDN
+    , "Pending inventories"
+  )
+  val removedNodesDitImpl = new InventoryDit(
+      new DN("ou=Removed Inventories, ou=Inventories, cn=rudder-configuration")
+    , softwareDN
+    ,"Removed Servers"
+  )
+  val inventoryDitService: InventoryDitService = new InventoryDitServiceImpl(pendingNodesDitImpl, acceptedNodesDitImpl, removedNodesDitImpl)
+
+  val inventoryMapper: InventoryMapper = new InventoryMapper(inventoryDitService, pendingNodesDitImpl, acceptedNodesDitImpl, removedNodesDitImpl)
+
+  val repo = new FullInventoryRepositoryImpl(inventoryDitService, inventoryMapper, ldap)
+
+
+  val allStatus = Seq(RemovedInventory, PendingInventory, AcceptedInventory)
+
+
+  case class BoxedResult[T](b: Box[T]) {
+    def isOK: org.specs2.execute.Result = b match {
+      case Full(x) => success
+      case eb: EmptyBox => failure((eb ?~! "Error").messageChain)
+    }
+  }
+
+  implicit def box2matcher[T](b:Box[T]): BoxedResult[T] = BoxedResult(b)
+
+
+  //shortcut to create a machine with the name has ID in the given status
+  def machine(name: String, status: InventoryStatus) = MachineInventory(
+        MachineUuid(name)
+      , status
+      , PhysicalMachineType
+      , Some(s"name for ${name}")
+      , None, None, None
+      , Nil, Nil, Nil, Nil, Nil, Nil, Nil, Nil, Nil
+    )
+  //shortcut to create a node with the name has ID and the given machine, in the
+  //given status, has container.
+  def node(name: String, status: InventoryStatus, container:(MachineUuid, InventoryStatus)) = NodeInventory(
+      NodeSummary(
+          NodeId(name)
+        , status
+        , "root", "localhost", Linux(Debian, "foo", new Version("1.0"), None, new Version("1.0")), NodeId("root")
+      )
+    , machineId = Some(container)
+  )
+
+  def full(n:NodeInventory, m:MachineInventory) = FullInventory(n, Some(m))
+
+  //just to validate that things are set up
+  "The in memory LDAP directory" should {
+
+    "correctly load and read back test-entries" in {
+
+
+      val numEntries = (0 /: bootstrapLDIFs) { case (x,path) =>
+        val reader = new com.unboundid.ldif.LDIFReader(path)
+        var i = 0
+        while(reader.readEntry != null) i += 1
+        i + x
+      }
+
+
+
+      ldap.server.countEntries === numEntries
+    }
+
+  }
+
+
+
+  "Saving, finding and moving machine around" should {
+
+    "correctly save and find a machine based on it's id (when only on one place)" in {
+      forall(allStatus) { status =>
+
+        val m = machine("machine in " + status.name, status)
+        repo.save(m)
+
+        val found = repo.get(m.id)
+
+        (m === found.openOrThrowException("For test")) and {
+          val d = repo.delete(m.id)
+          repo.delete(m.id)
+          val x = repo.get(m.id)
+          x must beEqualTo(Empty)
+          ok
+        }
+      }
+    }
+
+
+    "correctly find the machine of top priority when on several branches" in {
+      allStatus.foreach { status =>
+        repo.save(machine("m1", status))
+      }
+
+      val toFound = machine("m1", AcceptedInventory)
+      val found = repo.get(toFound.id)
+
+      toFound === found.openOrThrowException("For test")
+
+    }
+
+    "correctly moved the machine from pending to accepted, then to removed" in {
+      val m = machine("movingMachine", PendingInventory)
+
+      repo.save(m)
+
+
+      (
+        repo.move(m.id, AcceptedInventory).isOK
+        and m.copy(status = AcceptedInventory) === repo.get(m.id).openOrThrowException("For test")
+        and repo.move(m.id, RemovedInventory).isOK
+        and m.copy(status = RemovedInventory) === repo.get(m.id).openOrThrowException("For test")
+      )
+    }
+
+    ", when asked to move machine in removed inventory and a machine with the same id exists there, keep the one in removed and delete the one in accepted" in {
+      val m1 = machine("keepingMachine", AcceptedInventory)
+      val m2 = m1.copy(status = RemovedInventory, name = Some("modified"))
+
+      (
+        repo.save(m1).isOK
+        and repo.save(m2).isOK
+        and repo.move(m1.id, RemovedInventory).isOK
+        and {
+          val dn = inventoryDitService.getDit(AcceptedInventory).MACHINES.MACHINE.dn(m1.id)
+          m2 === repo.get(m1.id).openOrThrowException("For test") and ldap.server.entryExists(dn.toString) === false
+        }
+      )
+    }
+  }
+
+
+  "Saving, finding and moving node" should {
+
+    "find node for machine, whatever the presence or status of the machine" in {
+
+      val mid = MachineUuid("foo")
+
+      val n1 = node("acceptedNode", AcceptedInventory, (mid, AcceptedInventory))
+      val n2 = node("pendingNode", PendingInventory, (mid, AcceptedInventory))
+      val n3 = node("removedNode", RemovedInventory, (mid, AcceptedInventory))
+
+      def toDN(n:NodeInventory) = inventoryDitService.getDit(n.main.status).NODES.NODE.dn(n.main.id.value)
+
+      (
+        repo.save(FullInventory(n1, None)).isOK
+        and repo.save(FullInventory(n2, None)).isOK
+        and repo.save(FullInventory(n3, None)).isOK
+        and {
+          val res = ldap.map { con =>
+            repo.getNodesForMachine(con, mid).map { case (k,v) => (k, v.map( _.dn)) }
+          }
+          res.openOrThrowException("in test") must havePairs ( AcceptedInventory -> Set(toDN(n1)), PendingInventory -> Set(toDN(n2)), RemovedInventory -> Set(toDN(n3)))
+        }
+      )
+    }
+
+    "find back the machine after a move" in {
+      val m = machine("findBackMachine", PendingInventory)
+      val n = node("findBackNode", PendingInventory, (m.id, m.status))
+
+      (
+        repo.save(full(n, m)).isOK
+        and repo.move(n.main.id, PendingInventory, AcceptedInventory).isOK
+        and {
+          val FullInventory(node, machine) = repo.get(n.main.id, AcceptedInventory).openOrThrowException("in Test")
+
+          (
+            machine === Some(m.copy(status = AcceptedInventory)) and
+            node === n.copyWithMain(main => main.copy(status = AcceptedInventory)).copy(machineId = Some((m.id, AcceptedInventory)))
+          )
+        }
+      )
+    }
+
+    "accept to have a machine in a different status than the node" in {
+      val m = machine("differentMachine", AcceptedInventory)
+      val n = node("differentNode", PendingInventory, (m.id, AcceptedInventory))
+      (
+        repo.save(full(n, m)).isOK
+        and {
+          val FullInventory(node, machine) = repo.get(n.main.id, PendingInventory).openOrThrowException("in Test")
+
+          val direct = repo.get(m.id)
+
+          (
+            node === n
+            and machine === Some(m)
+          )
+        }
+      )
+    }
+
+    "not find a machine if the container information has a bad status" in {
+      val m = machine("invisibleMachine", PendingInventory)
+      val n = node("invisibleNode", PendingInventory, (m.id, AcceptedInventory))
+      (
+        repo.save(full(n, m)).isOK
+        and {
+          val FullInventory(node, machine) = repo.get(n.main.id, PendingInventory).openOrThrowException("in Test")
+
+          (
+            node === n
+            and machine === None
+          )
+        }
+      )
+    }
+
+    ", when moving from pending to accepted, moved back a machine from removed to accepted and correct other node container" in {
+      val m = machine("harcoreMachine", RemovedInventory)
+      val n0 = node("h-n0", PendingInventory, (m.id, PendingInventory))
+      val n1 = node("h-n1", PendingInventory, (m.id, PendingInventory))
+      val n2 = node("h-n2", AcceptedInventory, (m.id, AcceptedInventory))
+      val n3 = node("h-n3", RemovedInventory, (m.id, RemovedInventory))
+
+      (
+        repo.save(m).isOK and repo.save(FullInventory(n0,None)).isOK and repo.save(FullInventory(n1,None)).isOK and
+        repo.save(FullInventory(n2,None)).isOK and repo.save(FullInventory(n3,None)).isOK
+        and repo.move(n0.main.id, PendingInventory, AcceptedInventory).isOK
+        and {
+          val FullInventory(node0, m0) = repo.get(n0.main.id, AcceptedInventory).openOrThrowException("in Test")
+          val FullInventory(node1, m1) = repo.get(n1.main.id, PendingInventory).openOrThrowException("in Test")
+          val FullInventory(node2, m2) = repo.get(n2.main.id, AcceptedInventory).openOrThrowException("in Test")
+          val FullInventory(node3, m3) = repo.get(n3.main.id, RemovedInventory).openOrThrowException("in Test")
+
+          //expected machine value
+          val machine = m.copy(status = AcceptedInventory)
+          val ms = Some((machine.id, machine.status))
+
+          (
+            m0 === Some(machine) and m1 === Some(machine) and m2 === Some(machine) and m3 === Some(machine) and
+            node0 === n0.copyWithMain(main => main.copy(status = AcceptedInventory)).copy(machineId = Some((m.id, AcceptedInventory)))
+            and node1 === n1.copy(machineId = ms)
+            and node2 === n2.copy(machineId = ms)
+            and node3 === n3.copy(machineId = ms)
+          )
+        }
+      )
+    }
+
+  }
+
+
+   step {
+    ldap.close
+    success
+  }
+
+}


### PR DESCRIPTION
This a rather big pull request for a bug, but I didn't found a cleaner and smaller way to correct all the mess that was here. 

So now, the main logic is:
- a machine is identified by its ID, not its status. That means that in the case of the same machine with several status (what does not have any meaning), we always use the order Accepted > Pending > Remove
- the node's container DN is the truth for the node <-> machine link. If the link is false, we don't get back the machine with the node when requesting a node (but at least, we preciselly know what we were looking for). 
- when moving a machine or a node,  we are smart: we check for other nodes with that machine, look for the priority, and then only put the machine in the same status than the node of most priority, and above everything, we update all reference to that machine in node container.
- oh, and I added tests that cover all these intentions (what lead to #4464...)

With that, I hope to put a end to all the never ending stream of bugs around machine inventory (bad search, inventory not updating, missing information in webapp screens, etc)
