### PR TITLE
Fixes #5965: LDAP configuration is not optimized for Rudder use case

### DIFF
--- a/inventory-repository/src/main/resources/ldap/DB_CONFIG
+++ b/inventory-repository/src/main/resources/ldap/DB_CONFIG
@@ -28,7 +28,9 @@ set_lg_bsize 2097152
 set_flags DB_LOG_AUTOREMOVE
 
 # Locking system
-set_lk_max_locks 4000
+set_lk_max_locks 40000
+set_lk_max_lockers 40000
+set_lk_max_objects 40000
 
 # Note: special DB_CONFIG flags are no longer needed for "quick"
 # slapadd(8) or slapindex(8) access (see their -q option). 

--- a/inventory-repository/src/main/resources/ldap/slapd.conf
+++ b/inventory-repository/src/main/resources/ldap/slapd.conf
@@ -83,14 +83,27 @@ directory       /var/rudder/ldap/openldap-data
 # Checkpoint database every 128k written or every minute
 checkpoint      128       1
 
-# Indices to maintain
-index	objectClass	eq
-index	isEnabled,isDynamic,isModified,isSystem eq
-index	uuid eq
-index	container,software eq
+#
+# This config property must be dimensionned so that ALL 
+# entries of the directory feet in. 
+# The rought estimation to know the value correct value is
+# "number of node" x 500, with a minimum of 100 000 in all
+# case. 250 000 allows to not wonder what to do before
+# a long time and still keep memory rather low.
+# To now how many entry you directory has, you can exec:
+# ldapsearch -x -D "cn=Manager,cn=rudder-configuration" -w secret -b cn=rudder-configuration -s sub '* +'  > /tmp/entries
+# And look for '#numEntries: XXXX' (last line of the /tmp/entries file)
+cachesize 100000
 
-# Software search
-index   cn,softwareVersion  eq
+# good estimation is: 3 x cachesize
+idlcachesize 300000
+
+
+# Index to maintain
+# We purposelly NOT index things because our base is small, and
+# we massivelly use queries like "everething under that base",
+# so it is better to just have a cachesize containing all entries. 
+index	objectClass	eq
 
 database monitor
 


### PR DESCRIPTION
For the rationnal, see http://www.rudder-project.org/redmine/issues/5965

Note: for test, you will have to: 
- stop slapd: /etc/init.d/rudder-slapd stop
- remove unwanted indexes (see: http://www.rudder-project.org/redmine/issues/6105 for exaplanation about what files to keep/remove)
- reindex (/etc/init.d/rudder-slapd reindex)
- start slapd: /etc/init.d/rudder-slapd start
- warm the cache with the command (can be long - tens of seconds): ldapsearch -x -D "cn=Manager,cn=rudder-configuration" -w THE_PASSWORD -b cn=rudder-configuration -s sub + *  > /dev/null