### PR TITLE
Fixes #10119: Scala actors are deprecated in scala 2.11 and removed in 2.12: update inventory-endpoint

### DIFF
--- a/inventory-provisioning-web/pom.xml
+++ b/inventory-provisioning-web/pom.xml
@@ -66,17 +66,16 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <version>${rudder-version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.scala-lang</groupId>
-      <artifactId>scala-actors</artifactId>
-      <version>${scala-version}</version>
-    </dependency>
-
     <!-- Compile dependencies -->
     <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
       <version>1.3.2</version>
+    </dependency>
+    <dependency>
+      <groupId>io.monix</groupId>
+      <artifactId>monix-reactive_${scala-binary-version}</artifactId>
+      <version>${monix-version}</version>
     </dependency>
     <!-- Needed for fileupload -->
     <dependency>


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10119

The logic didn't change much: in place of an actor, we are using an asynchone queue provided by monixBufferedSubscriber (and as it is a subscriber, it is not parallel). So basically the same as an actor. 

The only major difference is that before, the queue size was known in the actor, not here. As we want to provide the info to users when they request so, we need to keep count by ourself. 