### PR TITLE
Fixes #6019: Node details shows Operating System Type: MSWin for Windows node rather than Windows

### DIFF
--- a/inventory-api/src/main/scala/com/normation/inventory/domain/NodeInventory.scala
+++ b/inventory-api/src/main/scala/com/normation/inventory/domain/NodeInventory.scala
@@ -142,7 +142,7 @@ object UnknownOSType extends OsType {
 }
 
 sealed abstract class WindowsType extends OsType {
-  override val kernelName = "MSWin"
+  override val kernelName = "Windows"
 }
 object WindowsType {
   val allKnownTypes = (


### PR DESCRIPTION
https://issues.rudder.io/issues/6019